### PR TITLE
Add a tmeRepositoryConfig struct and a tmeRepositoryConfig initialisa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# tme-reader
+tme-reader
+==========
 
 [![Circle CI](https://circleci.com/gh/Financial-Times/tme-reader/tree/master.png?style=shield)](https://circleci.com/gh/Financial-Times/tme-reader/tree/master)
 
@@ -7,22 +8,33 @@ Retrieves General Terms from TME as a list of interfaces, letting the main appli
 The service exposes endpoints for getting all the terms and for getting a term by a tmeID.
 
 
-# Usage
-`go get github.com/Financial-Times/tme-reader/tmereader`
+Usage
+-----
+
+    go get github.com/Financial-Times/tme-reader/tmereader
 
 Available methods:
 
-* GetTmeTermsFromIndex(index int) (tmeTerms []interface{}, error) - returns a set of terms, having a maximum of `maxRecord` elements starting from the provided index 	
-* GetTmeTermById(tmeID string) (tmeTerm interface{}, error) - returns the term details, obtained by the tme term identifier
+* `GetTmeTermsFromIndex(index int) (tmeTerms []interface{}, error)` - returns a set of terms, having a maximum of `maxRecord` elements starting from the provided index
+* `GetTmeTermById(tmeID string) (tmeTerm interface{}, error)` - returns the term details, obtained by the tme term identifier
 
-# In order to run:
+To run, create a new repository, e.g.:
 
-Create a new repository:
-
-`NewTmeRepository(client httpClient, tmeBaseURL string, userName string, password string, token string, maxRecords int, slices int, taxonomyName string, modelTransformer modelTransformer)`
+    NewTimeRepositoryWithConfig(tmeRepositoryConfig{
+            client: &client,
+            tmeBaseURL: ,
+            userName: "username",
+            password: "password",
+            token: "token",
+            maxRecords: 100,
+            slices: 1,
+            taxonomyName: "GL",
+            source: &AuthorityFiles{},
+            modelTransformer: new(dummyTransformer),
+        })
 
 The modelTransformer should implement the following methods, according to his own model type:
 
-* UnMarshallTaxonomy(contents []byte) (tmeTerms []interface{}, error) - loading xml data into list of terms ([]tmeTerms)
-* UnMarshallTerm(content []byte) (tmeTerm interface{}, error) - loading xml data into a tmeTerm model
+* `UnMarshallTaxonomy(contents []byte) (tmeTerms []interface{}, error)` - loading xml data into list of terms (`[]tmeTerms`)
+* `UnMarshallTerm(content []byte) (tmeTerm interface{}, error)` - loading xml data into a tmeTerm model
 

--- a/tmereader/repository.go
+++ b/tmereader/repository.go
@@ -66,6 +66,32 @@ func NewTmeRepository(client httpClient, tmeBaseURL string, userName string, pas
 	return &tmeRepository{httpClient: client, tmeBaseURL: tmeBaseURL, accessConfig: tmeAccessConfig{userName: userName, password: password, token: token}, maxRecords: maxRecords, slices: slices, taxonomyName: taxonomyName, source: source, transformer: modelTransformer}
 }
 
+type tmeRepositoryConfig struct {
+	client httpClient
+	tmeBaseURL string
+	userName string
+	password string
+	token string
+	maxRecords int
+	slices int
+	taxonomyName string
+	source TmeSource
+	modelTransformer modelTransformer
+}
+
+func NewTimeRepositoryWithConfig(cfg tmeRepositoryConfig) Repository {
+	return &tmeRepository{
+		httpClient: cfg.client,
+		tmeBaseURL: cfg.tmeBaseURL,
+		accessConfig: tmeAccessConfig{userName: cfg.userName, password: cfg.password, token: cfg.token},
+		maxRecords: cfg.maxRecords,
+		slices: cfg.slices,
+		taxonomyName: cfg.taxonomyName,
+		source: cfg.source,
+		transformer: cfg.modelTransformer,
+	}
+}
+
 func (t *tmeRepository) GetTmeTermsFromIndex(startRecord int) ([]interface{}, error) {
 	chunks := t.maxRecords / t.slices
 

--- a/tmereader/repository_test.go
+++ b/tmereader/repository_test.go
@@ -152,11 +152,33 @@ func (*dummyTransformer) UnMarshallTerm(content []byte) (interface{}, error) {
 }
 
 func authorityFilesRepo(c dummyClient) Repository {
-	return &tmeRepository{httpClient: &c, tmeBaseURL: c.tmeBaseURL, accessConfig: tmeAccessConfig{userName: "test", password: "test", token: "test"}, maxRecords: 100, slices: 1, taxonomyName: "GL", source: &AuthorityFiles{}, transformer: new(dummyTransformer)}
+	return NewTimeRepositoryWithConfig(tmeRepositoryConfig{
+		client: &c,
+		tmeBaseURL: c.tmeBaseURL,
+		userName: "test",
+		password: "test",
+		token: "test",
+		maxRecords: 100,
+		slices: 1,
+		taxonomyName: "GL",
+		source: &AuthorityFiles{},
+		modelTransformer: new(dummyTransformer),
+	})
 }
 
 func knowledgeBasesRepo(c dummyClient) Repository {
-	return &tmeRepository{httpClient: &c, tmeBaseURL: c.tmeBaseURL, accessConfig: tmeAccessConfig{userName: "test", password: "test", token: "test"}, maxRecords: 100, slices: 1, taxonomyName: "GL", source: &KnowledgeBases{}, transformer: new(dummyTransformer)}
+	return NewTimeRepositoryWithConfig(tmeRepositoryConfig{
+		client: &c,
+		tmeBaseURL: c.tmeBaseURL,
+		userName: "test",
+		password: "test",
+		token: "test",
+		maxRecords: 100,
+		slices: 1,
+		taxonomyName: "GL",
+		source: &KnowledgeBases{},
+		modelTransformer: new(dummyTransformer),
+	})
 }
 
 func getFileReader(assert *assert.Assertions, name string) io.ReadCloser {


### PR DESCRIPTION
…tion function that uses it, to avoid any more problems with broken interfaces that some dependent applications were suffering.

```
$ go test
PASS
ok      github.com/Financial-Times/tme-reader/tmereader 0.019s
```

Hey folks, can you have a look at this small PR?

FYI this is currently breaking [v1-orgs-transformer](https://github.com/Financial-Times/v1-orgs-transformer), so I'll fix that library via a PR once this change is in `master`.
